### PR TITLE
Refactor: Systems now have to be registered to specs manually.

### DIFF
--- a/src/game_context.rs
+++ b/src/game_context.rs
@@ -73,9 +73,9 @@ impl GameContext {
     }
 
     pub fn register_resources(&mut self) {
-        self.world.insert(InputQueue::default());
+        self.world.insert(InputQueue::new());
         self.world.insert(GameState::default());
-        self.world.insert(SoundLibrary::default());
+        self.world.insert(SoundLibrary::new());
         self.world.insert(GameVars::default());
     }
 

--- a/src/resources/input_queue.rs
+++ b/src/resources/input_queue.rs
@@ -2,13 +2,18 @@ use ggez::event::KeyCode;
 use std::collections::VecDeque;
 
 
-#[derive(Default)]
 pub struct InputQueue {
     keys_pressed: VecDeque<KeyCode>
 }
 
 impl InputQueue {
     const MAX_LEN: usize = 20;
+
+    pub fn new() -> Self {
+        InputQueue {
+            keys_pressed: VecDeque::new()
+        }
+    }
 
     pub fn push(&mut self, keycode: KeyCode) {
         if self.keys_pressed.len() >= Self::MAX_LEN { self.keys_pressed.pop_front().unwrap(); }

--- a/src/resources/sound_library.rs
+++ b/src/resources/sound_library.rs
@@ -19,8 +19,8 @@ pub struct SoundLibrary {
     pub music_sound: MusicSound
 }
 
-impl Default for SoundLibrary {
-    fn default() -> Self {
+impl SoundLibrary {
+    pub fn new() -> Self {
         SoundLibrary { music_sound: MusicSound::new() }
     }
 }

--- a/src/systems/gameplay_state_system.rs
+++ b/src/systems/gameplay_state_system.rs
@@ -16,8 +16,8 @@ impl GameplayStateSystem {
 
 impl<'a> System<'a> for GameplayStateSystem {
     type SystemData = (
-        Write<'a, GameState>,
-        Write<'a, SoundLibrary>,
+        WriteExpect<'a, GameState>,
+        WriteExpect<'a, SoundLibrary>,
         ReadStorage<'a, Box>,
         ReadStorage<'a, Spot>,
         ReadStorage<'a, Renderable>

--- a/src/systems/input_system.rs
+++ b/src/systems/input_system.rs
@@ -1,4 +1,4 @@
-use specs::{System, ReadStorage, Write, Join, Entities, WriteStorage};
+use specs::{System, ReadStorage, Join, Entities, WriteStorage, WriteExpect};
 use crate::components::{Player, Position, Movable, Blocking, Renderable, Directional, Direction};
 use crate::resources::input_queue::InputQueue;
 use ggez::event::KeyCode;
@@ -46,8 +46,8 @@ impl InputSystem {
 
 impl<'a> System<'a> for InputSystem {
     type SystemData = (
-        Write<'a, InputQueue>,
-        Write<'a, GameState>,
+        WriteExpect<'a, InputQueue>,
+        WriteExpect<'a, GameState>,
         Entities<'a>,
         WriteStorage<'a, Renderable>,
         WriteStorage<'a, Directional>,

--- a/src/systems/rendering_system.rs
+++ b/src/systems/rendering_system.rs
@@ -1,5 +1,5 @@
 use ggez::{Context, graphics};
-use specs::{System, ReadStorage, Join, Read};
+use specs::{System, ReadStorage, Join, ReadExpect};
 use crate::components::Renderable;
 use ggez::graphics::{Image, DrawParam, Color};
 use ggez::nalgebra as na;
@@ -38,8 +38,8 @@ impl<'a> RenderingSystem<'a> {
 
 impl<'a> System<'a> for RenderingSystem<'a> {
     type SystemData = (
-        Read<'a, GameVars>,
-        Read<'a, GameState>,
+        ReadExpect<'a, GameVars>,
+        ReadExpect<'a, GameState>,
         ReadStorage<'a, Renderable>
     );
 


### PR DESCRIPTION
Register systems through `pub fn register_resources` in `struct GameContext`.
From now on use `specs::WriteExpect` instead of `specs::Write` and `specs::ReadExpect` instead of `specs::Read`.