### PR TITLE
Abolish custom entity traits enums.

### DIFF
--- a/data/entity_data.json
+++ b/data/entity_data.json
@@ -1,0 +1,66 @@
+{
+  "floor": {
+    "type": [
+      "clean",
+      "gravel",
+      "plant"
+      ],
+    "material": [
+      "concrete",
+      "dirt",
+      "grass",
+      "grass2",
+      "sand"
+    ]
+  },
+
+  "spot": {
+    "color": [
+      "beige",
+      "black",
+      "blue",
+      "brown",
+      "gray",
+      "purple",
+      "red",
+      "yellow",
+      "orange"
+    ]
+  },
+
+  "box": {
+    "brightness": [
+      "dark",
+      "bright"
+    ],
+    "color": [
+      "beige",
+      "black",
+      "blue",
+      "brown",
+      "gray",
+      "purple",
+      "red",
+      "yellow",
+      "orange"
+    ]
+  },
+
+  "wall": {
+    "shape": [
+      "square",
+      "round"
+    ],
+    "color": [
+      "beige",
+      "black",
+      "brown",
+      "gray",
+      "pompadourpink"
+    ]
+  },
+
+  "char": {
+    "direction": {}
+  }
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,4 @@
 use specs::{Component, VecStorage, NullStorage};
-use std::fmt::{Formatter, Display};
-use std::fmt;
 use std::collections::HashMap;
 
 
@@ -91,50 +89,6 @@ impl Box {
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum BoxSpotColor {
-    Beige,
-    Black,
-    Blue,
-    Brown,
-    Gray,
-    Purple,
-    Red,
-    Yellow,
-    Orange
-}
-
-impl Display for BoxSpotColor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Beige => write!(f, "beige"),
-            Self::Black => write!(f, "black"),
-            Self::Blue => write!(f, "blue"),
-            Self::Brown => write!(f, "brown"),
-            Self::Gray => write!(f, "gray"),
-            Self::Purple => write!(f, "purple"),
-            Self::Red => write!(f, "red"),
-            Self::Yellow => write!(f, "yellow"),
-            Self::Orange => write!(f, "orange")
-        }
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum BoxBrightness {
-    Dark,
-    Bright
-}
-
-impl Display for BoxBrightness {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Dark => write!(f, "dark"),
-            Self::Bright => write!(f, "bright")
-        }
-    }
-}
-
 #[derive(Component, Default)]
 #[storage(NullStorage)]
 pub struct Wall;
@@ -145,42 +99,6 @@ impl Wall {
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum WallColor {
-    Beige,
-    Black,
-    Brown,
-    Gray,
-    PompadourPink
-}
-
-impl Display for WallColor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Beige => write!(f, "beige"),
-            Self::Black => write!(f, "black"),
-            Self::Brown => write!(f, "brown"),
-            Self::Gray => write!(f, "gray"),
-            Self::PompadourPink => write!(f, "pompadourpink")
-        }
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum WallShape {
-    Square,
-    Round
-}
-
-impl Display for WallShape {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Square => write!(f, "square"),
-            Self::Round => write!(f, "round")
-        }
-    }
-}
-
 #[derive(Component, Default)]
 #[storage(NullStorage)]
 pub struct Spot;
@@ -188,43 +106,5 @@ pub struct Spot;
 impl Spot {
     pub fn new() -> Self {
         Spot {}
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum FloorMaterial {
-    Concrete,
-    Dirt,
-    Grass,
-    Grass2, // Grass but brighter
-    Sand
-}
-
-impl Display for FloorMaterial {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Concrete => write!(f, "concrete"),
-            Self::Dirt => write!(f, "dirt"),
-            Self::Grass => write!(f, "grass"),
-            Self::Grass2 => write!(f, "grass2"),
-            Self::Sand => write!(f, "sand")
-        }
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum FloorType {
-    Clean,
-    Gravel,
-    Plant
-}
-
-impl Display for FloorType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Clean => write!(f, "clean"),
-            Self::Gravel => write!(f, "gravel"),
-            Self::Plant => write!(f, "plant")
-        }
     }
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -7,6 +7,7 @@ pub const WINDOW_HEIGHT: f32 = TILE_SIZE * MAP_HEIGHT as f32;
 pub const RESOURCE_PREFIX_PATH: &'static str = "./resources";
 pub const SETTING_PATH: &'static str = "./data/settings.json";
 pub const GAME_DATA_PATH: &'static str = "./data/game_data.json";
+pub const ENTITY_DATA_PATH: &'static str = "./data/entity_data.json";
 
 pub const MAP_WIDTH: u8 = 12;
 pub const MAP_HEIGHT: u8 = 9;

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -7,40 +7,40 @@ use std::collections::HashMap;
 pub struct EntityBuilder;
 
 impl EntityBuilder {
-    pub fn create_wall(world: &mut World, position: Position, shape: WallShape, color: WallColor) {
+    pub fn create_wall(world: &mut World, position: Position, wall_shape: &str, wall_color: &str) {
         world.create_entity()
             .with(Renderable::from(
                 Position { z: WALL_Z, ..position },
                 "/images/wall_{wall_shape}_{wall_color}.png",
                 vec![
-                    (String::from("wall_shape"), shape.to_string()),
-                    (String::from("wall_color"), color.to_string())
+                    (String::from("wall_shape"), wall_shape.to_string()),
+                    (String::from("wall_color"), wall_color.to_string())
                 ].into_iter().collect()))
             .with(Wall::new())
             .with(Blocking::new())
             .build();
     }
 
-    pub fn create_floor(world: &mut World, position: Position, floor_type: FloorType, material: FloorMaterial) {
+    pub fn create_floor(world: &mut World, position: Position, floor_type: &str, floor_material: &str) {
         world.create_entity()
             .with(Renderable::from(
                 Position { z: FLOOR_Z, ..position },
                 "/images/floor_{floor_type}_{floor_material}.png",
                   vec![
                       (String::from("floor_type"), floor_type.to_string()),
-                      (String::from("floor_material"), material.to_string())
+                      (String::from("floor_material"), floor_material.to_string())
                   ].into_iter().collect()))
             .build();
     }
 
-    pub fn create_box(world: &mut World, position: Position, box_brightness: BoxBrightness, color: BoxSpotColor) {
+    pub fn create_box(world: &mut World, position: Position, box_brightness: &str, box_color: &str) {
         world.create_entity()
             .with(Renderable::from(
                 Position { z: BOX_Z, ..position },
                 "/images/box_{box_brightness}_{box_color}.png",
                 vec![
                       (String::from("box_brightness"), box_brightness.to_string()),
-                      (String::from("box_color"), color.to_string())
+                      (String::from("box_color"), box_color.to_string())
                 ].into_iter().collect()))
             .with(Box::new())
             .with(Blocking::new())
@@ -48,19 +48,19 @@ impl EntityBuilder {
             .build();
     }
 
-    pub fn create_spot(world: &mut World, position: Position, color: BoxSpotColor) {
+    pub fn create_spot(world: &mut World, position: Position, spot_color: &str) {
         world.create_entity()
             .with(Renderable::from(
                 Position { z: SPOT_Z, ..position },
                 "/images/spot_{spot_color}.png",
                 vec![
-                    (String::from("spot_color"), color.to_string())
+                    (String::from("spot_color"), spot_color.to_string())
                 ].into_iter().collect()))
             .with(Spot::new())
             .build();
     }
 
-    pub fn create_player(world: &mut World, position: Position, direction: Direction) {
+    pub fn create_player(world: &mut World, position: Position, player_direction: Direction) {
         world.create_entity()
             .with(Renderable::from(
                 Position { z: PLAYER_Z, ..position },
@@ -68,7 +68,7 @@ impl EntityBuilder {
                 HashMap::new()))
             .with(Player::new())
             .with(Movable::new())
-            .with(Directional::from(direction))
+            .with(Directional::from(player_direction))
             .build();
     }
 }


### PR DESCRIPTION
Remove custom enums relate to entity traits, including `BoxSpotColor`, `BoxBrightness`, `WallColor`, `WallShape`, `FloorMaterial`, `FloorType`.
This is because both processes of reading those traits from external map files and storing them in the game (which the latter will take place right after the first) don't require the enums to function, as both can work with traits in form of strings.
Therefore, `./data/entity_data.json` is created for the sake of validation and easier addition of traits, which stores all available entities, traits and their syntaxes.
Validation-while-reading-external-map code is also added.